### PR TITLE
由于引用activemq-all导致日志冲突，activemq-all改为activemq-client；

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- activemq -->
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-all</artifactId>
+            <artifactId>activemq-client</artifactId>
             <version>5.11.2</version>
         </dependency>
         <!--jsp lib dependency-->

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -36,7 +36,7 @@
  
 
         <!-- 添加mybatis日志打印  begin-->
-        <logger name="com.donbala.*" level="DEBUG" additivity="false">
+        <logger name="com.donbala" level="DEBUG" additivity="false">
         	<appender-ref ref="FILE"/>
         	<!-- 开发时如果想在控制台打印日志，则需要将下面这行注释放开 -->
  			<appender-ref ref="STDOUT"/>


### PR DESCRIPTION
logback不打印mybatis的sql日志，更改logback-spring配置文件，name="com.donbala.*"改为name="com.donbala"即可打印sql日志；